### PR TITLE
Unset `scalafixScalaBinaryVersion`

### DIFF
--- a/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
+++ b/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
@@ -100,7 +100,6 @@ object CirceOrgPlugin extends AutoPlugin {
 
   lazy val scalafixSettings: Seq[Setting[_]] =
     Seq(
-      scalafixScalaBinaryVersion := (LocalRootProject / scalaBinaryVersion).value,
       scalafixDependencies ++= Seq(
         "com.github.liancheng" %% "organize-imports" % "0.6.0" // https://github.com/liancheng/scalafix-organize-imports/tags
       )


### PR DESCRIPTION
This is unneeded for the organize imports rule and currently breaks things for Scala 3.