### PR TITLE
Set default for `circeRootOfCodeCoverage`

### DIFF
--- a/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
+++ b/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
@@ -49,7 +49,8 @@ object CirceOrgPlugin extends AutoPlugin {
 
   lazy val codeCoverageSettings: Seq[Setting[_]] = Seq(
     coverageHighlighting := true,
-    coverageExcludedPackages := "io.circe.examples.*"
+    coverageExcludedPackages := "io.circe.examples.*",
+    circeRootOfCodeCoverage := None
   )
 
   lazy val publishSettings: Seq[Setting[_]] =


### PR DESCRIPTION
So it doesn't break the build if it's not set.