### PR TITLE
Remove `${{matrix.java}}` from codecov flags

### DIFF
--- a/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
+++ b/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
@@ -90,7 +90,7 @@ object CirceOrgPlugin extends AutoPlugin {
                     "v2"
                   ),
                   params = Map(
-                    "flags" -> List("${{matrix.scala}}", "${{matrix.java}}").mkString(",")
+                    "flags" -> List("${{matrix.scala}}").mkString(",")
                   )
                 )
               )


### PR DESCRIPTION
That variable prevents the coverage report from being uploaded if it
contains an `@`, see: https://github.com/circe/circe-config/pull/361#issuecomment-1419646677