### PR TITLE
scalafix 0.11.0 includes the organize imports rule

### DIFF
--- a/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
+++ b/core/src/main/scala/io/circe/sbt/CirceOrgPlugin.scala
@@ -101,9 +101,7 @@ object CirceOrgPlugin extends AutoPlugin {
 
   lazy val scalafixSettings: Seq[Setting[_]] =
     Seq(
-      scalafixDependencies ++= Seq(
-        "com.github.liancheng" %% "organize-imports" % "0.6.0" // https://github.com/liancheng/scalafix-organize-imports/tags
-      )
+      scalafixDependencies ++= Seq.empty
     )
 
 }


### PR DESCRIPTION
This can be merged after #19 