### PR TITLE
bump version to 0.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val core = project
     name := "sbt-circe-org"
   )
 
-ThisBuild / tlBaseVersion := "0.3"
+ThisBuild / tlBaseVersion := "0.4"
 ThisBuild / crossScalaVersions := Seq("2.12.19")
 ThisBuild / developers := List(
   tlGitHubDev("lorandszakacs", "Loránd Szakács")


### PR DESCRIPTION
upgrade of sbt-typelevel to 0.7.0 has some breaking changes, lets upgrade the series here to signal this.